### PR TITLE
docs: fix demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ TL;DR:
  - if you want to render GFM exactly like github, use [comrak](https://github.com/kivikakk/comrak)
  - if you want to define your own syntax (like `@mentions`, `:emoji:`, custom html classes), use this library
 
-You can check a [demo](https://rlidwka.github.io/markdown-it.rs/) in your browser *(it's Rust compiled into WASM)*.
+You can check a [demo](https://markdown-it-rust.github.io/markdown-it/) in your browser *(it's Rust compiled into WASM)*.
 
 ### Features
 


### PR DESCRIPTION
Hi markdown-it team,

Thanks for all your hard work!

It looks like the demo link got broken during the repo transfer so I updated it.
However, the functionality of the demo site still seems to break.
